### PR TITLE
fix: run_cmd 中 data 清零问题

### DIFF
--- a/mid-homework/telnet-server.c
+++ b/mid-homework/telnet-server.c
@@ -9,7 +9,7 @@ static void sig_int(int signo) {
 
 char *run_cmd(char *cmd) {
     char *data = malloc(16384);
-    bzero(data, sizeof(data));
+    bzero(data, 16384);
     FILE *fdp;
     const int max_buffer = 256;
     char buffer[max_buffer];


### PR DESCRIPTION
这里 sizeof 得出的是指针的大小